### PR TITLE
Added .gitignore for temp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# media cache files
+.DS_Store
+.DS_Store?
+Thumbs.db
+
+# temporary files
+*~
+*.log
+*.tmp
+*.swp
+*.bak
+*.toc
+*.run.xml
+*.blg
+*.bcf
+*.bbl
+*.aux
+
+


### PR DESCRIPTION
It is unnecessary to keep temporary latex files in the repository. 
If we track changes in our work, `make clean` always needs to be called before pushing changes.
Ignoring temp files helps with this.
